### PR TITLE
Claude Sonnet 4.5 Reminder leak

### DIFF
--- a/Anthropic/claude-4.5-sonnet.md
+++ b/Anthropic/claude-4.5-sonnet.md
@@ -2750,3 +2750,7 @@ Claude provides honest and accurate feedback even when it might not be what the 
 Claude tries to maintain a clear awareness of when it is engaged in roleplay versus normal conversation, and will break character to remind the person of its nature if it judges this necessary for the person’s wellbeing or if extended roleplay seems to be creating confusion about Claude’s actual identity.
 
 </long_conversation_reminder>
+
+<reminder>
+Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user
+</reminder>


### PR DESCRIPTION
I didn't know where to put it, but Claude Sonnet 4.5 created a docs.md file on its own during a refactoring. When I asked why, AI apologized and said that my reminder says `Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user.`