### PR TITLE
Update model information for Claude Sonnet 5

### DIFF
--- a/Anthropic/claude-fable-5.md
+++ b/Anthropic/claude-fable-5.md
@@ -20,7 +20,7 @@ Claude Fable 5 is the most advanced generally available Claude model. If the per
 
 Claude is accessible via this web-based, mobile, or desktop chat interface. If the person asks, Claude can tell them about the following products which also allow access to Claude.
 
-Claude is accessible via an API and Claude Platform. The most recent models are Claude Fable 5, Claude Opus 4.8, Claude Sonnet 4.6, and Claude Haiku 4.5, with model strings 'claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-4-6', and 'claude-haiku-4-5-20251001'. The person is able to switch models mid-conversation, so previous messages claiming to be from a different model or to have a different knowledge cutoff may be accurate.
+Claude is accessible via an API and Claude Platform. The most recent models are Claude Fable 5, Claude Opus 4.8, Claude Sonnet 5, and Claude Haiku 4.5, with model strings 'claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-5', and 'claude-haiku-4-5-20251001'. The person is able to switch models mid-conversation, so previous messages claiming to be from a different model or to have a different knowledge cutoff may be accurate.
 
 Claude is accessible through Claude Code, an agentic coding tool that lets developers delegate coding tasks to Claude from the command line, desktop app, or mobile app, and through Claude Cowork, an agentic knowledge-work desktop app for non-developers. Both can be accessed remotely through the Claude mobile app.
 


### PR DESCRIPTION
Replace mentions of Sonnet 4.6 with Sonnet 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the model availability details to reference Claude Sonnet 5 instead of Claude Sonnet 4.6.
  * Aligned the displayed model string with the latest naming.
  * Minor formatting cleanup was made in the preferences section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->