### PR TITLE
Add structured prompt metadata and automated validation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,49 @@ Thanks for helping grow this collection! Here's how to contribute.
 
 5. Paste the raw system prompt as-is. Don't summarize or paraphrase — the full, unedited text is the point.
 
-6. Commit, push to your fork, and open a PR back to this repo.
+6. (Optional but encouraged) Add metadata for your file — see below.
+
+7. Commit, push to your fork, and open a PR back to this repo.
+
+## Adding metadata (optional but encouraged)
+
+New prompt files can be described with a small YAML metadata entry recording
+provenance (how the prompt was obtained) and confidence (how strongly it's
+been verified). This is **optional** — a prompt with no metadata is still a
+perfectly good contribution — but adding it makes the repository easier to
+search and helps readers judge how much to trust an entry.
+
+Metadata lives in sidecar files under `metadata/`, one per top-level
+provider directory, **never** inside the prompt file itself. To add an
+entry for `OpenAI/example.md`, add (or edit) `metadata/OpenAI.yaml`:
+
+```yaml
+OpenAI/example.md:
+  provider: openai
+  product: chatgpt
+  model: gpt-example        # optional
+  captured_at: 2026-09-01   # optional, YYYY-MM-DD
+  source_type: extracted    # official | extracted | reverse_engineered |
+                             # community_submitted | reconstructed | unknown
+  confidence: medium        # high | medium | low | unknown
+  contains:                 # optional
+    - system_prompt
+```
+
+Full field definitions, the meaning of each `source_type` and `confidence`
+value, and the migration policy (existing files don't need this
+retroactively) are in [`docs/METADATA.md`](../docs/METADATA.md).
+
+Before opening a PR, validate your entry locally:
+
+```bash
+pip install -r scripts/requirements.txt
+python scripts/validate_metadata.py
+```
+
+This reports pass/fail per `metadata/*.yaml` file and lists any prompt
+files with no metadata as informational output — that's expected and not
+a failure. CI runs the same check on every PR.
 
 ## Requesting a prompt
 

--- a/.github/workflows/validate-metadata.yml
+++ b/.github/workflows/validate-metadata.yml
@@ -1,0 +1,58 @@
+name: Validate prompt metadata
+
+# Validates metadata/*.yaml sidecar files (see docs/METADATA.md) against
+# schemas/prompt-metadata.schema.json using scripts/validate_metadata.py,
+# and runs that script's own pytest suite (tests/).
+#
+# Two metadata checks, matching the migration policy in docs/METADATA.md:
+#   1. Integrity (blocking): malformed YAML, schema violations, dangling
+#      paths, entries filed under the wrong provider, cross-file
+#      duplicates. This never fails just because a prompt file has no
+#      metadata yet -- most of the repository doesn't, and that's fine.
+#   2. Coverage on pull requests (informational, non-blocking): flags .md
+#      files added or modified in the PR that still have no metadata
+#      entry, as a nudge, without blocking the merge. Once the metadata
+#      convention is more established, drop `continue-on-error` on that
+#      step to make it blocking too.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt -r tests/requirements.txt
+
+      - name: Run validator test suite
+        run: pytest -q
+
+      - name: Validate metadata integrity
+        run: python scripts/validate_metadata.py --quiet
+
+      - name: Fetch PR base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+
+      - name: Check metadata coverage for changed prompt files (non-blocking)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          python scripts/validate_metadata.py \
+            --require-changed "origin/${{ github.event.pull_request.base.ref }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python artifacts from scripts/validate_metadata.py and its tests
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Common OS/editor cruft
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ Leaked system prompts, captured verbatim — the hidden instructions and rules t
 
 ---
 
+## Contributing
+
+Have a prompt to add? See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md)
+for how to submit one. New entries can optionally carry structured metadata
+(provenance and confidence) recorded in `metadata/*.yaml` — see
+[`docs/METADATA.md`](docs/METADATA.md) for the format; it's validated
+automatically in CI.
+
 
 ## Contact
 

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -118,6 +118,12 @@ entries; omit rather than guess.
 captured_at: 2026-09-01
 ```
 
+> **Note:** YAML parsers (including PyYAML's `safe_load`, used by the
+> validator) parse an unquoted `YYYY-MM-DD` value as a native date object,
+> not a string. The validator normalizes this automatically before checking
+> it against the schema, so writing the date unquoted as shown above is
+> fine and preferred.
+
 ### `source_type` (required)
 
 How the material became available. One of:

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -1,0 +1,204 @@
+# Prompt Metadata
+
+This document specifies an optional, machine-readable metadata layer for the
+prompt files in this repository. It describes **provenance** (how a prompt was
+obtained) and **confidence** (how strongly it has been verified), plus a small
+amount of structural information (provider, product, model, capture date,
+contents).
+
+The goal is to make the repository queryable — "which prompts are officially
+published?", "which are single-source extractions?", "which contain tool
+definitions?" — without changing how prompts are read or contributed today.
+
+## Design principle: prompt files are never modified
+
+Every `.md` prompt file in this repository is meant to be pasted **as-is**,
+verbatim (see `.github/CONTRIBUTING.md` and `.gitattributes`, which disables
+whitespace normalization for `*.md` specifically to preserve raw formatting).
+Some files (Claude Code's `SKILL.md`, agent, and output-style files) already
+contain their *own* YAML front matter as part of the leaked content itself —
+that front matter is data being archived, not repository metadata, and must
+not be touched or conflated with what this document defines.
+
+For that reason, metadata described here is **never** injected into prompt
+files as front matter. It lives in separate **sidecar files**, one per
+top-level provider directory, so a prompt file's byte content never changes
+because of a metadata edit.
+
+## Storage format
+
+Metadata lives under `metadata/`, one YAML file per top-level directory in
+the repository, named identically to that directory:
+
+```text
+metadata/
+├── Anthropic.yaml
+├── OpenAI.yaml
+├── Google.yaml
+├── xAI.yaml
+├── Perplexity.yaml
+├── Misc.yaml
+├── ...
+```
+
+Each file is a YAML mapping from **repository-relative path** (forward
+slashes, exactly as `git ls-files` prints it) to a metadata object:
+
+```yaml
+Anthropic/official/2026-09-01-claude-fable-5.1.md:
+  provider: anthropic
+  product: claude-fable-5.1
+  model: claude-fable-5.1
+  captured_at: 2026-09-01
+  source_type: official
+  confidence: high
+  contains:
+    - system_prompt
+
+Anthropic/claude-code/claude-code-fable-5.1.md:
+  provider: anthropic
+  product: claude-code
+  model: claude-fable-5.1
+  captured_at: 2026-09-05
+  source_type: extracted
+  confidence: medium
+  contains:
+    - system_prompt
+    - tool_definitions
+```
+
+A path with no entry in the matching sidecar file is a **legacy entry** —
+valid, just not yet described (see [Migration policy](#migration-policy)).
+
+### Why a sidecar per top-level directory (and not one big file)
+
+- Keeps each file to a reviewable size and scoped to one provider, so a PR
+  adding one prompt touches one small, obviously-related metadata file.
+- Avoids merge conflicts between unrelated providers landing in the same PR
+  window.
+- Maps 1:1 onto the directory structure contributors already use, so "which
+  file describes `Anthropic/...`" has one obvious answer.
+
+## Fields
+
+### `provider` (required)
+
+The company or organization associated with the prompt, lowercase, matching
+the top-level directory's subject (not necessarily its literal casing):
+
+```yaml
+provider: anthropic
+```
+
+### `product` (required)
+
+The product, application, or agent the prompt belongs to:
+
+```yaml
+product: claude-code
+```
+
+### `model` (optional)
+
+The specific model associated with the prompt, when known. Optional because
+some prompts are product-level rather than tied to one model (e.g. a
+`README.md` describing a folder, or a tool schema shared across models).
+
+```yaml
+model: claude-fable-5.1
+```
+
+### `captured_at` (optional)
+
+The date the prompt was captured, extracted, published, or observed, as
+`YYYY-MM-DD`. Optional because the exact date is sometimes unknown for older
+entries; omit rather than guess.
+
+```yaml
+captured_at: 2026-09-01
+```
+
+### `source_type` (required)
+
+How the material became available. One of:
+
+| Value | Meaning |
+|---|---|
+| `official` | Intentionally published by the provider (e.g. a provider's own published system-prompt disclosure, release notes, or documentation). |
+| `extracted` | Obtained from a running product or model through an extraction method (a prompt-leak technique against the live product). |
+| `reverse_engineered` | Derived from client code, application bundles, network traffic, APIs, or related technical analysis rather than asking the model to reveal itself. |
+| `community_submitted` | Supplied by a contributor without the stronger verification the categories above imply. |
+| `reconstructed` | Assembled from partial evidence (fragments, paraphrases, multiple partial captures) rather than one direct capture. |
+| `unknown` | The original acquisition method cannot be established. |
+
+### `confidence` (required)
+
+How strongly the entry has been verified — a statement about verification
+quality, not a personal opinion about whether the prompt "looks real". One of:
+
+| Value | Use when |
+|---|---|
+| `high` | At least one strong verification condition holds: provider-published material, independently reproduced extraction, multiple matching captures, or strong technical evidence tied to the real product. |
+| `medium` | The source is plausible and internally consistent, but independent reproduction is limited. |
+| `low` | The content depends mainly on a single unverified submission or an incomplete extraction. |
+| `unknown` | Verification information is not available. |
+
+Confidence is not computed automatically anywhere in this system — it is a
+human judgment call the contributor records, and it is fine (expected, even)
+for most existing entries to be `unknown` until someone reviews them.
+
+### `contains` (optional)
+
+A list describing what the document holds, from:
+
+```text
+system_prompt
+tool_definitions
+skills
+subagents
+mcp
+safety_rules
+permission_rules
+verification_rules
+runtime_instructions
+```
+
+Example:
+
+```yaml
+contains:
+  - system_prompt
+  - tool_definitions
+  - skills
+```
+
+## Migration policy
+
+Converting all 400+ existing prompt files at once would produce an
+unreviewable diff and is explicitly **not** part of this change. Instead:
+
+- **Existing files** are allowed to have no entry in the sidecar file
+  ("legacy"). The validator treats a missing entry as a warning, not a
+  failure.
+- **New or modified prompt files touched by a PR** are expected to gain a
+  metadata entry in the matching sidecar file as part of that PR. The
+  validator can be run in a stricter mode (see
+  [`scripts/validate_metadata.py`](../scripts/validate_metadata.py), added in
+  a later task) that enforces this for changed paths only.
+- Backfilling legacy entries is encouraged but happens gradually, file by
+  file or provider by provider, in follow-up PRs — never as one bulk
+  migration commit.
+
+## Non-goals for this iteration
+
+- No automatic confidence scoring. A human sets `confidence`; the system only
+  checks that the value is one of the allowed enums.
+- No enforcement that *every* file eventually gets metadata — legacy entries
+  remain permanently valid unless someone chooses to describe them.
+- No change to prompt file content, naming, or directory layout.
+
+## Related files
+
+- JSON Schema: [`schemas/prompt-metadata.schema.json`](../schemas/prompt-metadata.schema.json)
+- Validator: [`scripts/validate_metadata.py`](../scripts/validate_metadata.py)
+- CI workflow: [`.github/workflows/validate-metadata.yml`](../.github/workflows/validate-metadata.yml)

--- a/metadata/Anthropic.yaml
+++ b/metadata/Anthropic.yaml
@@ -1,0 +1,32 @@
+# Metadata for Anthropic/ prompt files.
+# See docs/METADATA.md for field definitions and docs/METADATA.md#migration-policy
+# for why most files in this folder have no entry here yet.
+
+Anthropic/official/2026-09-01-claude-fable-5.1.md:
+  provider: anthropic
+  product: claude.ai
+  model: claude-fable-5.1
+  captured_at: 2026-09-01
+  source_type: official
+  confidence: high
+  contains:
+    - system_prompt
+
+Anthropic/claude-fable-5.1.md:
+  provider: anthropic
+  product: claude.ai
+  model: claude-fable-5.1
+  captured_at: 2026-09-01
+  source_type: extracted
+  confidence: medium
+  contains:
+    - system_prompt
+
+Anthropic/claude-code/skills/code-review/SKILL.md:
+  provider: anthropic
+  product: claude-code
+  captured_at: 2026-09-09
+  source_type: extracted
+  confidence: medium
+  contains:
+    - skills

--- a/metadata/Google.yaml
+++ b/metadata/Google.yaml
@@ -1,0 +1,11 @@
+# Metadata for Google/ prompt files. See docs/METADATA.md.
+
+Google/gemini-3.7-flash.md:
+  provider: google
+  product: gemini
+  model: gemini-3.7-flash
+  captured_at: 2026-08-18
+  source_type: extracted
+  confidence: medium
+  contains:
+    - system_prompt

--- a/metadata/Misc.yaml
+++ b/metadata/Misc.yaml
@@ -1,0 +1,10 @@
+# Metadata for Misc/ prompt files. See docs/METADATA.md.
+
+Misc/warp-2.0-agent.md:
+  provider: warp
+  product: warp-agent-mode
+  captured_at: 2026-05-07
+  source_type: community_submitted
+  confidence: low
+  contains:
+    - system_prompt

--- a/metadata/OpenAI.yaml
+++ b/metadata/OpenAI.yaml
@@ -1,0 +1,12 @@
+# Metadata for OpenAI/ prompt files. See docs/METADATA.md.
+
+OpenAI/Codex/gpt-6-astra.md:
+  provider: openai
+  product: codex
+  model: gpt-6-astra
+  captured_at: 2026-09-04
+  source_type: extracted
+  confidence: medium
+  contains:
+    - system_prompt
+    - skills

--- a/metadata/xAI.yaml
+++ b/metadata/xAI.yaml
@@ -1,0 +1,13 @@
+# Metadata for xAI/ prompt files. See docs/METADATA.md.
+
+xAI/grok-4.6.md:
+  provider: xai
+  product: grok
+  model: grok-4.6
+  captured_at: 2026-08-29
+  source_type: extracted
+  confidence: medium
+  contains:
+    - system_prompt
+    - skills
+    - safety_rules

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/schemas/prompt-metadata.schema.json
+++ b/schemas/prompt-metadata.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/asgeirtj/system_prompts_leaks/schemas/prompt-metadata.schema.json",
+  "title": "Prompt metadata sidecar file",
+  "description": "Schema for one metadata/<Provider>.yaml sidecar file, as defined in docs/METADATA.md. The file is a mapping from repository-relative prompt file path to a metadata entry describing that file's provenance, confidence, and basic structure. Prompt files themselves are never modified by this schema.",
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "#/$defs/entry"
+  },
+  "propertyNames": {
+    "$comment": "Keys are repository-relative paths using forward slashes, matching `git ls-files` output.",
+    "type": "string",
+    "minLength": 1,
+    "pattern": "^[^\\\\]+$"
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "title": "Metadata entry",
+      "required": ["provider", "product", "source_type", "confidence"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The company or organization associated with the prompt, e.g. \"anthropic\", \"openai\", \"google\", \"xai\"."
+        },
+        "product": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The product, application, or agent the prompt belongs to, e.g. \"claude-code\", \"chatgpt\", \"gemini-cli\"."
+        },
+        "model": {
+          "type": ["string", "null"],
+          "description": "The specific model associated with the prompt, when known. Optional/null for product-level entries not tied to one model."
+        },
+        "captured_at": {
+          "type": ["string", "null"],
+          "description": "The date the prompt was captured, extracted, published, or observed, formatted YYYY-MM-DD. Omit (null) rather than guess.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "format": "date"
+        },
+        "source_type": {
+          "description": "How the material became available. See docs/METADATA.md for full definitions.",
+          "enum": [
+            "official",
+            "extracted",
+            "reverse_engineered",
+            "community_submitted",
+            "reconstructed",
+            "unknown"
+          ]
+        },
+        "confidence": {
+          "description": "How strongly the entry has been verified. See docs/METADATA.md for full definitions.",
+          "enum": ["high", "medium", "low", "unknown"]
+        },
+        "contains": {
+          "type": "array",
+          "description": "What the document holds.",
+          "items": {
+            "enum": [
+              "system_prompt",
+              "tool_definitions",
+              "skills",
+              "subagents",
+              "mcp",
+              "safety_rules",
+              "permission_rules",
+              "verification_rules",
+              "runtime_instructions"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# Dependencies for scripts/validate_metadata.py
+PyYAML>=6.0
+jsonschema>=4.18

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Validate metadata/<Provider>.yaml sidecar files.
+
+See docs/METADATA.md for the full metadata specification and
+schemas/prompt-metadata.schema.json for the machine-readable schema.
+
+Each file under metadata/ is a YAML mapping of repository-relative prompt
+path -> metadata entry. This script:
+
+  1. Parses every metadata/*.yaml file (reports malformed YAML).
+  2. Validates each file's contents against the JSON Schema (reports every
+     violation per entry: missing required fields, invalid enum values,
+     invalid date format, unknown keys, etc.).
+  3. Confirms every path an entry describes actually exists in the repo
+     (catches typos and stale entries after a file is renamed or removed).
+  4. Confirms an entry lives in the sidecar file matching its own top-level
+     directory (catches copy-paste mistakes, e.g. an OpenAI/... path
+     documented in metadata/Anthropic.yaml).
+  5. Flags a path documented in more than one sidecar file.
+  6. Reports prompt files with no metadata entry at all ("legacy") as
+     informational output, not a failure -- see the migration policy in
+     docs/METADATA.md. Pass --require-changed <git-ref> to instead treat
+     legacy status as a failure for prompt files that are new or modified
+     relative to <git-ref> (intended for CI on a pull request). Pass
+     --strict to require metadata for every prompt file in the repository.
+
+Exit status is non-zero if anything in 1-5 fails, or if 6 fails under
+--require-changed / --strict.
+
+Usage:
+    python scripts/validate_metadata.py
+    python scripts/validate_metadata.py --require-changed origin/main
+    python scripts/validate_metadata.py --strict
+    python scripts/validate_metadata.py --quiet
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dependency check
+    print("error: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - dependency check
+    print("error: jsonschema is required (pip install jsonschema)", file=sys.stderr)
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_METADATA_DIR = REPO_ROOT / "metadata"
+DEFAULT_SCHEMA_PATH = REPO_ROOT / "schemas" / "prompt-metadata.schema.json"
+
+# Top-level directories that never hold prompt content and are excluded when
+# scanning the repo for "legacy" (undocumented) prompt files.
+EXCLUDED_TOP_LEVEL_DIRS = {
+    ".github",
+    "assets",
+    "docs",
+    "schemas",
+    "scripts",
+    "tests",
+    "metadata",
+}
+# Specific filenames that are repo/folder documentation rather than a
+# leaked prompt, wherever they appear.
+EXCLUDED_BASENAMES = {"README.md", "CONTRIBUTING.md"}
+
+
+class SidecarResult:
+    """Validation outcome for a single metadata/<Provider>.yaml file."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.errors: list[str] = []
+        self.entry_count = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def add(self, message: str) -> None:
+        self.errors.append(message)
+
+
+def stringify_dates(value: Any) -> Any:
+    """Recursively convert YAML-parsed date/datetime objects to ISO 8601
+    strings. PyYAML resolves an unquoted YYYY-MM-DD scalar to a native
+    datetime.date, but the schema (and JSON in general) expects a string."""
+    if isinstance(value, dict):
+        return {k: stringify_dates(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [stringify_dates(v) for v in value]
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    return value
+
+
+def display_path(path: Path) -> str:
+    """Repo-relative POSIX path for display, falling back to the absolute
+    path if `path` lies outside REPO_ROOT (e.g. a --metadata-dir override
+    pointing elsewhere, such as in tests)."""
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def load_schema(schema_path: Path) -> dict:
+    with schema_path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def discover_sidecar_files(metadata_dir: Path) -> list[Path]:
+    if not metadata_dir.is_dir():
+        return []
+    return sorted(metadata_dir.glob("*.yaml"))
+
+
+def discover_prompt_files() -> list[str]:
+    """List every git-tracked .md file outside infrastructure directories,
+    as repo-relative POSIX paths. Uses `git ls-files` so untracked scratch
+    files and .gitignore'd content are never treated as prompt content."""
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "*.md"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        top = line.split("/", 1)[0]
+        name = line.rsplit("/", 1)[-1]
+        if top in EXCLUDED_TOP_LEVEL_DIRS or name in EXCLUDED_BASENAMES:
+            continue
+        paths.append(line)
+    return paths
+
+
+class BadGitRefError(Exception):
+    pass
+
+
+def get_changed_paths(ref: str) -> set[str]:
+    """Paths of .md files added or modified relative to `ref` (working tree
+    vs. that ref), per `git diff --name-only`."""
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "diff", "--name-only", ref, "--", "*.md"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BadGitRefError(
+            f"'git diff {ref}' failed -- is {ref!r} a valid git ref? "
+            f"({result.stderr.strip()})"
+        )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def validate_sidecar_file(
+    sidecar_path: Path,
+    schema: dict,
+    validator: jsonschema.protocols.Validator,
+    seen_paths: dict[str, Path],
+) -> SidecarResult:
+    result = SidecarResult(sidecar_path)
+    rel_sidecar = display_path(sidecar_path)
+
+    try:
+        with sidecar_path.open(encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        result.add(f"malformed YAML: {exc}")
+        return result
+
+    if raw is None:
+        raw = {}
+
+    if not isinstance(raw, dict):
+        result.add(
+            f"top level must be a mapping of path -> metadata entry, got {type(raw).__name__}"
+        )
+        return result
+
+    doc = stringify_dates(raw)
+    result.entry_count = len(doc)
+
+    for error in sorted(validator.iter_errors(doc), key=lambda e: list(e.path)):
+        loc = "/".join(str(p) for p in error.path) or "<top level>"
+        result.add(f"{loc}: {error.message}")
+
+    # Sidecar file name should match the top-level directory it documents,
+    # e.g. metadata/OpenAI.yaml documents OpenAI/... paths.
+    expected_top = sidecar_path.stem
+
+    for entry_path in doc.keys():
+        if not isinstance(entry_path, str):
+            continue  # already reported by schema validation (propertyNames)
+
+        full_path = REPO_ROOT / entry_path
+        if not full_path.is_file():
+            result.add(f"{entry_path}: path does not exist in the repository")
+
+        actual_top = entry_path.split("/", 1)[0]
+        if actual_top != expected_top:
+            result.add(
+                f"{entry_path}: documented in {rel_sidecar}, "
+                f"but belongs under {actual_top}/ "
+                f"(expected metadata/{actual_top}.yaml)"
+            )
+
+        if entry_path in seen_paths:
+            other = display_path(seen_paths[entry_path])
+            result.add(f"{entry_path}: duplicate entry (also documented in {other})")
+        else:
+            seen_paths[entry_path] = sidecar_path
+
+    return result
+
+
+def run(
+    metadata_dir: Path,
+    schema_path: Path,
+    require_changed: str | None,
+    strict: bool,
+    quiet: bool,
+) -> int:
+    schema = load_schema(schema_path)
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+
+    sidecar_files = discover_sidecar_files(metadata_dir)
+    seen_paths: dict[str, Path] = {}
+    results = [
+        validate_sidecar_file(path, schema, validator, seen_paths)
+        for path in sidecar_files
+    ]
+
+    any_failed = False
+    for result in results:
+        rel = display_path(result.path)
+        if result.ok:
+            print(f"PASS {rel} ({result.entry_count} entries)")
+        else:
+            any_failed = True
+            print(f"FAIL {rel}")
+            for err in result.errors:
+                print(f"  - {err}")
+
+    documented = set(seen_paths.keys())
+    prompt_files = discover_prompt_files()
+    legacy = sorted(set(prompt_files) - documented)
+
+    if strict:
+        enforced_missing = legacy
+    elif require_changed:
+        try:
+            changed = get_changed_paths(require_changed)
+        except BadGitRefError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        enforced_missing = sorted(p for p in legacy if p in changed)
+    else:
+        enforced_missing = []
+
+    if not quiet and legacy:
+        label = "without metadata"
+        if strict:
+            label += " (--strict: treated as failures)"
+        elif require_changed:
+            label += f" (informational unless changed since {require_changed})"
+        else:
+            label += " (informational only, see docs/METADATA.md migration policy)"
+        print(f"\n{len(legacy)} of {len(prompt_files)} prompt file(s) {label}:")
+        preview = legacy if strict or require_changed else legacy[:10]
+        for p in preview:
+            marker = " [FAIL]" if p in enforced_missing else ""
+            print(f"  - {p}{marker}")
+        remaining = len(legacy) - len(preview)
+        if remaining > 0:
+            print(f"  ... and {remaining} more")
+
+    if enforced_missing:
+        any_failed = True
+        if quiet:
+            print(f"\n{len(enforced_missing)} changed/required prompt file(s) missing metadata:")
+            for p in enforced_missing:
+                print(f"  - {p}")
+
+    total = len(results)
+    failed = sum(1 for r in results if not r.ok)
+    print(f"\n{total} sidecar file(s) checked, {failed} failed.")
+    if enforced_missing:
+        print(f"{len(enforced_missing)} required prompt file(s) missing metadata.")
+
+    return 1 if any_failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--metadata-dir",
+        type=Path,
+        default=DEFAULT_METADATA_DIR,
+        help="directory containing metadata/*.yaml sidecar files (default: metadata/)",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help="path to the JSON Schema (default: schemas/prompt-metadata.schema.json)",
+    )
+    parser.add_argument(
+        "--require-changed",
+        metavar="REF",
+        help="fail if a .md file added/modified relative to REF has no metadata entry",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="fail if ANY prompt file in the repository has no metadata entry",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="don't print the full legacy-file listing, only failures and the summary",
+    )
+    args = parser.parse_args(argv)
+
+    if args.strict and args.require_changed:
+        parser.error("--strict and --require-changed are mutually exclusive")
+
+    return run(
+        metadata_dir=args.metadata_dir,
+        schema_path=args.schema,
+        require_changed=args.require_changed,
+        strict=args.strict,
+        quiet=args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+"""Shared fixtures for scripts/validate_metadata.py's test suite."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "prompt-metadata.schema.json"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import validate_metadata as vm  # noqa: E402  (import after sys.path tweak)
+
+# Prompt files that exist in every temp_repo fixture, matched by the sidecar
+# fixtures under tests/fixtures/ (which all key off "Anthropic/example.md").
+FIXTURE_PROMPT_FILES = [
+    "Anthropic/example.md",
+    "OpenAI/example.md",
+    "Google/example.md",
+]
+
+
+@pytest.fixture
+def temp_repo(tmp_path, monkeypatch):
+    """A throwaway git repository containing a few real (dummy) prompt
+    files, wired up as the validator's REPO_ROOT. This lets path-existence
+    checks and `git diff`/`git ls-files` calls run against isolated fixture
+    content instead of the real repository being worked on.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+
+    for rel in FIXTURE_PROMPT_FILES:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"Example prompt content for {rel}.\n", encoding="utf-8")
+
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True)
+
+    monkeypatch.setattr(vm, "REPO_ROOT", repo)
+    return repo
+
+
+@pytest.fixture
+def metadata_dir(temp_repo):
+    path = temp_repo / "metadata"
+    path.mkdir()
+    return path
+
+
+def copy_fixture(name: str, dest_dir: Path, dest_name: str | None = None) -> Path:
+    """Copy tests/fixtures/<name> into dest_dir, optionally under a
+    different filename (used to control which sidecar file a fixture's
+    entries land in, e.g. testing a path documented under the wrong
+    provider)."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / (dest_name or name)
+    shutil.copyfile(FIXTURES_DIR / name, dest)
+    return dest
+
+
+def run_validator(metadata_dir: Path, **overrides) -> int:
+    """Call vm.run() with sane defaults, capturing nothing itself -- use
+    pytest's `capsys` fixture in the test to inspect stdout/stderr."""
+    kwargs = dict(
+        metadata_dir=metadata_dir,
+        schema_path=SCHEMA_PATH,
+        require_changed=None,
+        strict=False,
+        quiet=True,
+    )
+    kwargs.update(overrides)
+    return vm.run(**kwargs)

--- a/tests/fixtures/dangling-path.yaml
+++ b/tests/fixtures/dangling-path.yaml
@@ -1,0 +1,5 @@
+Anthropic/this-file-does-not-exist.md:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: high

--- a/tests/fixtures/invalid-confidence.yaml
+++ b/tests/fixtures/invalid-confidence.yaml
@@ -1,0 +1,5 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: verified

--- a/tests/fixtures/invalid-date.yaml
+++ b/tests/fixtures/invalid-date.yaml
@@ -1,0 +1,6 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: high
+  captured_at: "01/01/2026"

--- a/tests/fixtures/invalid-source-type.yaml
+++ b/tests/fixtures/invalid-source-type.yaml
@@ -1,0 +1,5 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: leaked
+  confidence: high

--- a/tests/fixtures/malformed.yaml
+++ b/tests/fixtures/malformed.yaml
@@ -1,0 +1,3 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: [unterminated

--- a/tests/fixtures/missing-confidence.yaml
+++ b/tests/fixtures/missing-confidence.yaml
@@ -1,0 +1,4 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: official

--- a/tests/fixtures/non-string-key.yaml
+++ b/tests/fixtures/non-string-key.yaml
@@ -1,0 +1,5 @@
+2026:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: high

--- a/tests/fixtures/not-a-mapping.yaml
+++ b/tests/fixtures/not-a-mapping.yaml
@@ -1,0 +1,3 @@
+- just
+- a
+- list

--- a/tests/fixtures/unexpected-property.yaml
+++ b/tests/fixtures/unexpected-property.yaml
@@ -1,0 +1,6 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: high
+  extra_field: not-allowed

--- a/tests/fixtures/unknown-contains.yaml
+++ b/tests/fixtures/unknown-contains.yaml
@@ -1,0 +1,7 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  source_type: official
+  confidence: high
+  contains:
+    - made_up_value

--- a/tests/fixtures/valid.yaml
+++ b/tests/fixtures/valid.yaml
@@ -1,0 +1,9 @@
+Anthropic/example.md:
+  provider: anthropic
+  product: example-product
+  model: example-model
+  captured_at: 2026-01-01
+  source_type: official
+  confidence: high
+  contains:
+    - system_prompt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+# Test-only dependencies. Runtime deps for the validator itself are in
+# scripts/requirements.txt -- install both:
+#   pip install -r scripts/requirements.txt -r tests/requirements.txt
+pytest>=7.0

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -1,0 +1,306 @@
+"""Tests for scripts/validate_metadata.py.
+
+Run with:
+    pip install -r scripts/requirements.txt -r tests/requirements.txt
+    pytest
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from conftest import copy_fixture, run_validator, vm
+
+
+# ---------------------------------------------------------------------------
+# Schema-shaped failures: one fixture each, isolating a single violation.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_entry_passes(metadata_dir, capsys):
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "PASS metadata/Anthropic.yaml (1 entries)" in out
+
+
+def test_missing_required_field_fails(metadata_dir, capsys):
+    copy_fixture("missing-confidence.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "FAIL metadata/Anthropic.yaml" in out
+    assert "'confidence' is a required property" in out
+
+
+def test_invalid_confidence_value_fails(metadata_dir, capsys):
+    copy_fixture("invalid-confidence.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "'verified' is not one of" in out
+
+
+def test_invalid_source_type_fails(metadata_dir, capsys):
+    copy_fixture("invalid-source-type.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "'leaked' is not one of" in out
+
+
+def test_invalid_date_format_fails(metadata_dir, capsys):
+    copy_fixture("invalid-date.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "does not match" in out
+    assert "01/01/2026" in out
+
+
+def test_unquoted_date_is_normalized_and_passes(metadata_dir, capsys):
+    # valid.yaml uses an unquoted 2026-01-01, which PyYAML parses as a
+    # datetime.date rather than a string -- the validator must normalize
+    # this before checking it against the schema's string pattern.
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    assert code == 0
+    assert "FAIL" not in capsys.readouterr().out
+
+
+def test_unknown_contains_value_fails(metadata_dir, capsys):
+    copy_fixture("unknown-contains.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "'made_up_value' is not one of" in out
+
+
+def test_unexpected_property_rejected(metadata_dir, capsys):
+    copy_fixture("unexpected-property.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "extra_field" in out
+
+
+def test_malformed_yaml_fails(metadata_dir, capsys):
+    copy_fixture("malformed.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "malformed YAML" in out
+
+
+def test_top_level_not_a_mapping_fails(metadata_dir, capsys):
+    copy_fixture("not-a-mapping.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "must be a mapping" in out
+
+
+def test_non_string_key_reported_without_crashing(metadata_dir, capsys):
+    copy_fixture("non-string-key.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "FAIL metadata/Anthropic.yaml" in out
+
+
+# ---------------------------------------------------------------------------
+# Sidecar-specific integrity checks (path existence, placement, duplicates).
+# ---------------------------------------------------------------------------
+
+
+def test_dangling_path_fails(metadata_dir, capsys):
+    copy_fixture("dangling-path.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "does not exist in the repository" in out
+
+
+def test_entry_in_wrong_sidecar_file_fails(metadata_dir, capsys):
+    # valid.yaml documents "Anthropic/example.md" but we save it as
+    # Google.yaml -- the path's real top-level directory doesn't match.
+    copy_fixture("valid.yaml", metadata_dir, "Google.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "belongs under Anthropic/" in out
+    assert "expected metadata/Anthropic.yaml" in out
+
+
+def test_duplicate_entry_across_sidecar_files_fails(metadata_dir, capsys):
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic-duplicate.yaml")
+
+    code = run_validator(metadata_dir)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "duplicate entry" in out
+
+
+def test_no_metadata_dir_passes_with_zero_checked(temp_repo, capsys):
+    missing_dir = temp_repo / "metadata"  # never created
+
+    code = run_validator(missing_dir)
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "0 sidecar file(s) checked, 0 failed." in out
+
+
+# ---------------------------------------------------------------------------
+# Legacy files: informational by default, enforced under --strict /
+# --require-changed.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_files_are_informational_by_default(metadata_dir, capsys):
+    # Only Anthropic/example.md is documented; OpenAI/ and Google/ examples
+    # are legacy but must not fail validation.
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir, quiet=False)
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "2 of 3 prompt file(s)" in out
+    assert "informational only" in out
+
+
+def test_strict_fails_when_files_undocumented(metadata_dir, capsys):
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+
+    code = run_validator(metadata_dir, strict=True)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "required prompt file(s) missing metadata" in out
+
+
+def test_strict_passes_when_fully_documented(temp_repo, metadata_dir, capsys):
+    for rel, filename in [
+        ("Anthropic/example.md", "Anthropic.yaml"),
+        ("OpenAI/example.md", "OpenAI.yaml"),
+        ("Google/example.md", "Google.yaml"),
+    ]:
+        (metadata_dir / filename).write_text(
+            f"""{rel}:
+  provider: test
+  product: test
+  source_type: official
+  confidence: high
+""",
+            encoding="utf-8",
+        )
+
+    code = run_validator(metadata_dir, strict=True)
+
+    assert code == 0
+
+
+def test_require_changed_flags_only_changed_undocumented_files(
+    temp_repo, metadata_dir, capsys
+):
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+
+    # Modify an undocumented prompt file without committing -- `git diff`
+    # against HEAD will see it as changed.
+    (temp_repo / "OpenAI" / "example.md").write_text("changed\n", encoding="utf-8")
+
+    code = run_validator(metadata_dir, require_changed="HEAD", quiet=True)
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "OpenAI/example.md" in out
+    # Google/example.md is also undocumented but untouched -- must not be
+    # enforced.
+    assert "Google/example.md" not in out
+
+
+def test_require_changed_passes_when_changed_file_is_documented(
+    temp_repo, metadata_dir, capsys
+):
+    copy_fixture("valid.yaml", metadata_dir, "Anthropic.yaml")
+    (temp_repo / "Anthropic" / "example.md").write_text("changed\n", encoding="utf-8")
+
+    code = run_validator(metadata_dir, require_changed="HEAD", quiet=True)
+
+    assert code == 0
+
+
+def test_require_changed_bad_ref_reports_clean_error(metadata_dir, capsys):
+    code = run_validator(metadata_dir, require_changed="not-a-real-ref")
+
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "not-a-real-ref" in err
+
+
+def test_strict_and_require_changed_are_mutually_exclusive(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        vm.main(["--strict", "--require-changed", "HEAD"])
+
+    assert excinfo.value.code == 2
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Small unit tests for helper functions.
+# ---------------------------------------------------------------------------
+
+
+def test_stringify_dates_converts_nested_date_objects():
+    value = {
+        "captured_at": datetime.date(2026, 1, 1),
+        "nested": {"a": [datetime.date(2025, 12, 31), "keep-me"]},
+        "unchanged": "already-a-string",
+    }
+
+    result = vm.stringify_dates(value)
+
+    assert result == {
+        "captured_at": "2026-01-01",
+        "nested": {"a": ["2025-12-31", "keep-me"]},
+        "unchanged": "already-a-string",
+    }
+
+
+def test_display_path_falls_back_outside_repo_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(vm, "REPO_ROOT", tmp_path / "somewhere")
+    outside = tmp_path / "elsewhere" / "file.yaml"
+
+    assert vm.display_path(outside) == str(outside)


### PR DESCRIPTION
## Problem

Prompt entries currently have no consistent, machine-readable way to describe provenance (how a prompt was obtained), confidence (how strongly it's been verified), or basic structure (provider/product/model/date/contents).
File names and directory placement carry that information informally, which works for browsing but not for automated analysis, and gives readers no way to tell an officially-published prompt apart from a single unverified extraction.

## Solution

Adds an optional, backward-compatible metadata layer: a JSON Schema, a Python validator with a test suite, a GitHub Actions workflow, and documentation — plus metadata for 7 representative files across providers to prove it out. No prompt file's content is modified anywhere in this PR.

### Design: sidecar files, not front matter

Metadata lives in `metadata/<Provider>.yaml` (one per top-level directory), each a mapping of repo-relative path → metadata entry — **not** injected into the prompt files themselves. This matters here specifically: several prompt files under `Anthropic/claude-code/` (agents, `SKILL.md`, output styles) already carry their *own* YAML front matter as part of the leaked content being archived, and the repo's contribution rule is to paste prompts verbatim. A sidecar format avoids colliding with that content and keeps every prompt file byte-for-byte unchanged.

### What's included

- **`docs/METADATA.md`** — the specification: field definitions (`provider`, `product`, `model`, `captured_at`, `source_type`, `confidence`, `contains`), the meaning of each `source_type` (official / extracted / reverse_engineered / community_submitted / reconstructed / unknown) and `confidence` level (high / medium / low / unknown), and an explicit migration policy: existing files need no entry ("legacy"), new or modified files are expected to gain one going forward, backfill happens gradually.
- **`schemas/prompt-metadata.schema.json`** — JSON Schema (draft 2020-12) validating a whole sidecar file: required `provider`/`product`/ `source_type`/`confidence`, optional `model`/`captured_at`/`contains`, `additionalProperties: false` to catch typos.
- **`scripts/validate_metadata.py`** — validates every `metadata/*.yaml` file: malformed YAML, schema violations, dangling paths (entry points at a file that doesn't exist), misplaced entries (path documented under the wrong provider), and cross-file duplicates are always failures. Files with no metadata are reported as informational output only, per the migration policy — never a hard failure by default. Two flags change that for CI: `--require-changed <ref>` (fail only for prompt files added/modified relative to `<ref>` that still lack metadata) and `--strict` (fail if any prompt file lacks metadata, for a future fully-migrated state).
- **`tests/`** — a pytest suite (24 tests) covering every schema failure mode, the sidecar-specific integrity checks, legacy-file handling under default/`--strict`/`--require-changed`, and helper-function unit tests, using a throwaway git-repo fixture so tests never touch real repository content.
- **`.github/workflows/validate-metadata.yml`** — runs the pytest suite plus the validator on every PR and on push to `main`. The integrity checks are blocking; the coverage nudge for newly-touched prompt files is informational (`continue-on-error: true`) so this doesn't retroactively require metadata on every future prompt-only PR from day one.
- **Representative metadata** for one file per provider, chosen for type diversity: an Anthropic official release-notes capture, the full claude.ai prompt for the same model, a Claude Code `SKILL.md`, a Codex system prompt, a Gemini web system prompt, a Grok prompt with explicit safety rules, and a smaller community-submitted CLI-agent prompt.
- **`.github/CONTRIBUTING.md` / `README.md`** updates documenting the optional metadata step and linking to the spec.
- A repo-root `.gitignore` (there wasn't one) for the Python artifacts the validator and its tests produce.

## Compatibility

Fully backward-compatible. Existing prompt files need no changes and are never flagged as failing; only 7 of 430+ files carry metadata after this PR, entirely by design (see "Recommended Scope" below).

## Validation

- `python scripts/validate_metadata.py`: all 5 sidecar files PASS, 0 failures; the ~400 files with no entry are reported as informational only.
- `pytest`: 24/24 passing.
- `--require-changed <pre-PR-commit>`: 0 enforced failures — this PR neither modifies nor adds any prompt file.
- `--strict`: correctly still fails while legacy files remain undocumented (expected/by design).
- Diffed the full PR against the commit before this work: only `.github/CONTRIBUTING.md` and `README.md` are modified (purely additive — one renumbered list item, otherwise new sections only), every other changed path is a new file, and **zero files under any provider directory (`Anthropic/`, `OpenAI/`, `Google/`, `xAI/`, ...) are touched.**
- `actionlint` passes on the new workflow with no findings; both the `pull_request` and `push`-triggered runs completed successfully in CI on the fork before opening this PR.

## Recommended scope for this PR

Deliberately narrow, per the usual guidance for infrastructure PRs on this repo: metadata spec + schema + validator + tests + CI + docs + a handful of representative examples, **not** a full-repository migration, database, or UI. Backfilling the remaining ~400 files is left for incremental follow-up PRs, file by file or provider by provider — never a single bulk commit.

## Future work (not in this PR)

- Duplicate/near-duplicate detection via content fingerprinting.
- A generated `dist/prompts.json` / `.jsonl` export once metadata coverage is broader.
- Gradually backfilling `captured_at`/`source_type`/`confidence` for existing entries.
